### PR TITLE
사이드바에서 정보 가져왔던 부분의 로직을 변경(페이지 로드가 끝나면 비동기적으로 사용자의 과거 기록 (현재는 정보수집 쪽만,…

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ from src.rule.rule import router as rule_router
 from src.finalreport.finalreport_routes import router as final_router
 from src.mypage.mypage_routes import router as mypage_router
 from src.settings.settings_routes import router as settings_router
+from src.sidebar.sidebar_route import router as sidebar_router
 import uvicorn
 import asyncio
 from src.getinfo import rpatools
@@ -38,6 +39,7 @@ app.include_router(rule_router)
 app.include_router(final_router)
 app.include_router(mypage_router)
 app.include_router(settings_router)
+app.include_router(sidebar_router)
 
 if __name__ == "__main__":
     uvicorn.run("src.main:app", host="127.0.0.1", port=8000, reload=True)

--- a/src/root/root.py
+++ b/src/root/root.py
@@ -1,8 +1,6 @@
-from fastapi import APIRouter, Request, Depends
+from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
-from src.database.supabase_client import get_supabase_client
-from src.root.root_service import get_past_cve_list
 
 router = APIRouter()
 
@@ -10,22 +8,5 @@ templates = Jinja2Templates(directory="src/templates")
 
 # 메인페이지 요청 라우터
 @router.get("/", response_class=HTMLResponse)
-async def get_info_page(request: Request, client=Depends(get_supabase_client)):
-    user_cookie = request.cookies.get("user")  # 쿠키에서 사용자 정보를 가져옴
-
-    # 로그인 여부에 따른 처리
-    if user_cookie:
-        # 로그인한 경우 CVE 리스트를 가져옴
-        past_cve_list = get_past_cve_list(client=client, request=request)
-    else:
-        # 로그인하지 않은 경우 빈 리스트 처리
-        past_cve_list = []
-
-    # 디버깅용 출력
-    print(f"User: {user_cookie}, CVE List: {past_cve_list}")
-
-    # 템플릿에 'past_cve' 정보 전달
-    return templates.TemplateResponse(
-        "getinfo.html", 
-        {"request": request, "past_cve_list": past_cve_list}
-    )
+async def get_info_page(request: Request):
+    return templates.TemplateResponse("getinfo.html", {"request": request})

--- a/src/sidebar/sidebar_route.py
+++ b/src/sidebar/sidebar_route.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter, Request, Depends
+from src.database.supabase_client import get_supabase_client
+from src.sidebar.sidebar_service import get_past_cve_list
+
+router = APIRouter()
+
+@router.get("/past_info")
+async def get_past_info(request: Request, client=Depends(get_supabase_client)):
+    past_cve_list = await get_past_cve_list(client, request)  # client, request 순서 맞추기
+    return {"past_cve_list": past_cve_list}

--- a/src/sidebar/sidebar_service.py
+++ b/src/sidebar/sidebar_service.py
@@ -1,18 +1,23 @@
 from supabase import Client
 from fastapi import HTTPException, Request
 
-def get_past_cve_list(client: Client, request: Request):
+async def get_past_cve_list(client: Client, request: Request):
     # 쿠키에서 사용자 정보 가져오기
     user = request.cookies.get("user")
     
+    if not user:
+        raise HTTPException(status_code=401, detail="User not authenticated")
+    
     # 사용자 정보 가져오기 
     user_info = client.auth.get_user(user)
-    if not user_info:
+    
+    # user_info가 None인 경우 에러 처리
+    if not user_info or not user_info.user:
         raise HTTPException(status_code=404, detail="User not found")
     
     user_id = user_info.user.id
     
-    # 해당 사용자의 정보 수집(CVE) 리스트 가져오기
+    # 해당 사용자의 CVE 리스트 가져오기
     response = client.table("info").select("cve").eq("user_id", user_id).execute()
     
     # 데이터가 없는 경우에 대한 처리

--- a/src/static/assets/js/main.js
+++ b/src/static/assets/js/main.js
@@ -318,6 +318,8 @@
 
 })();
 
+// 여기서부터 커스텀 스크립트 ================================================================================
+
 // 요청 url의 # 제거 스크립트
 window.onload = function () {
   var fragment = window.location.hash.substring(1); // '#' 제거
@@ -336,4 +338,27 @@ document.addEventListener("DOMContentLoaded", function () {
           link.classList.add("active");  // 현재 페이지의 URL과 일치하는 링크에 'active' 클래스 추가
       }
   });
+});
+
+document.addEventListener("DOMContentLoaded", async () => {
+  try {
+    const response = await fetch('/past_info');
+    if (response.ok) {
+        const data = await response.json();
+        const pastCveList = data.past_cve_list;
+        const listContainer = document.getElementById('past-cve-list');
+
+        pastCveList.forEach(cve => {
+            const listItem = document.createElement('li');
+            listItem.innerHTML = `<a href="/getinfo?cve_code=${cve.cve}">
+                                  <i class="bi bi-circle"></i><span>${cve.cve}</span>
+                                </a>`;
+            listContainer.appendChild(listItem);
+        });
+    } else {
+        console.error("Failed to fetch past CVE list");
+    }
+  } catch (error) {
+    console.error("Error fetching CVE list: ", error);
+  }
 });

--- a/src/templates/finalreport.html
+++ b/src/templates/finalreport.html
@@ -110,5 +110,8 @@
 <!-- Template Main JS File -->
 <script src="../static/assets/js/main.js"></script>
 
+<!-- getinfo Js File -->
+<script src="../static/scripts/finalreport.js"></script>
+
 </body>
 </html>

--- a/src/templates/sidebar.html
+++ b/src/templates/sidebar.html
@@ -12,20 +12,16 @@
             {% if request.cookies.get('user') %}
             <li class="nav-item">
                 <a class="nav-link collapsed" data-bs-target="#info-collection-nav" data-bs-toggle="collapse" href="#">
-                    <i class="bi bi-menu-button-wide"></i><span>정보 수집 목록</span><i
-                        class="bi bi-chevron-down ms-auto"></i>
+                    <i class="bi bi-menu-button-wide"></i><span>정보 수집 목록</span><i class="bi bi-chevron-down ms-auto"></i>
                 </a>
                 <ul id="info-collection-nav" class="nav-content collapse" data-bs-parent="#info-collection-parent">
-                    {% for cve in past_cve_list %}
-                    <li>
-                        <a href="/getinfo?cve_code={{ cve.cve }}">
-                            <i class="bi bi-circle"></i><span>{{ cve.cve }}</span>
-                        </a>
-                    </li>
-                    {% endfor %}
+                    <!-- 동적으로 추가될 과거 CVE 리스트 -->
+                    <div id="past-cve-list">
+                        <!-- 여기에 리스트 항목이 추가될 예정 -->
+                    </div>
                 </ul>
             </li>
-            {% endif %}
+        {% endif %}
     
             <li class="nav-item">
                 <a class="nav-link" href="/ruletest">


### PR DESCRIPTION
…) 을 가져와서 동적으로 리스트를 생성하기때문에  .html을 렌더링할때 데이터를 같이 전달해줄 필요없음)